### PR TITLE
merge from component-template-designer

### DIFF
--- a/.github/workflows/browser_ci.yml
+++ b/.github/workflows/browser_ci.yml
@@ -8,13 +8,13 @@ jobs:
         os:
           - ubuntu-latest
         node:
-          - 16.13.2
+          - 16.14.0
         browser:
           - chrome
           - firefox
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3.0.0
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -22,7 +22,7 @@ jobs:
       - run: npm test
         env:
           BROWSER: ${{ matrix.browser }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: ${{ github.workspace }}/build/test/**/*
           retention-days: 3
@@ -34,9 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3.0.0
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.2
+          node-version: 16.14.0
           cache: npm
       - run: npm install
       - run: npx semantic-release

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -19,9 +19,9 @@ jobs:
         uses: github/codeql-action/init@v1
         with:
           languages: javascript
-      - uses: actions/setup-node@v3.0.0
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.2
+          node-version: 16.14.0
           cache: npm
       - run: npm install
       - name: Perform CodeQL Analysis

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,5 @@ doc
 .github
 *.map
 netlify.toml
+pkg
+jsconfig.json

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   ],
   "license": "BSD-2-Clause",
   "scripts": {
-    "prepare": "rollup -c rollup.config.mjs",
-    "start": "rollup -c -w rollup.config.mjs",
+    "prepare": "rollup -c rollup.config.mjs && rollup -c",
+    "start": "rollup -c -w rollup.config.mjs && rollup -c -w",
     "test": "npm run test:cafe",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --app-init-delay 5000 --app \"rollup -c rollup.config.mjs -w\"",
-    "build": "rollup -c rollup.config.mjs"
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*.js -s build/test --app-init-delay 5000 --app \"rollup -c  -w\"",
+    "build": "rollup -c rollup.config.mjs && rollup -c"
   },
   "dependencies": {
     "aggregation-repository-provider": "^4.0.47",

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf8" />
+    <base href="/services/component-template-designer/">
+
+    <script src="./main.mjs" type="module"></script>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="application-name" content="Component Template Designer">
+    <meta name="apple-mobile-web-app-title" content="Component Template Designer">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="mobile-web-app-capable" content="yes">
+
+    <title>Component Template Designer</title>
+
+    <link rel="icon" href="images/icon.ico" type="image/x-icon" />
+    <link rel="icon" href="images/icon.svg" type="image/svg+xml" sizes="any" />
+    <link rel="apple-touch-icon" href="images/icon.png" />
+
+    <link rel="manifest" href="manifest.webmanifest" />
+  </head>
+
+  <body></body>
+</html>

--- a/src/public/manifest.webmanifest
+++ b/src/public/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "{{name}}",
+  "short_name": "{{name}}",
+  "description": "{{description}}",
+  "start_url": ".",
+  "display": "standalone",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "images/icon.svg",
+      "sizes": "150x150",
+      "purpose": "any"
+    }
+  ],
+  "background_color": "#ffffff",
+  "categories": []
+}


### PR DESCRIPTION
package.json
---
- chore(scripts): add rollup -c rollup.config.mjs && rollup -c (scripts.prepare)
chore(scripts): add rollup -c -w rollup.config.mjs && rollup -c -w (scripts.start)
chore(scripts): add testcafe $BROWSER:headless tests/cafe/*.js -s build/test --app-init-delay 5000 --app "rollup -c  -w" (scripts.test:cafe)
chore(scripts): add rollup -c rollup.config.mjs && rollup -c (scripts.build)

.github/workflows/codeql_analysis.yml
---
- chore: add actions/setup-node@v3 (jobs.analyze.steps.uses)
chore: add 16.14.0 (jobs.analyze.steps.with.node-version)

.npmignore
---
- chore: add pkg ()
chore: add jsconfig.json ()

src/index.html
---
- add missing src/index.html from template

src/public/manifest.webmanifest
---
- chore: add {{name}} (name)
chore: add {{name}} (short_name)
chore: add {{description}} (description)
chore: (categories)
chore: add #ffffff (background_color)
chore: add . (start_url)
chore: add standalone (display)
chore: add portrait (orientation)
chore: (icons)

.github/workflows/browser_ci.yml
---
- chore(deps): add 16.14.0 remove 16.13.2 (jobs.test.strategy.matrix.node)
chore: add actions/setup-node@v3 (jobs.test.steps.uses)
chore: add actions/upload-artifact@v3 (jobs.test.steps.uses)
chore: add actions/setup-node@v3 (jobs.release.steps.uses)
chore: add 16.14.0 (jobs.release.steps.with.node-version)

